### PR TITLE
Feat/02 slideshow

### DIFF
--- a/assets/component-slideshow.css
+++ b/assets/component-slideshow.css
@@ -21,6 +21,7 @@ slideshow-component .slideshow.banner {
 }
 
 @media screen and (max-width: 749px) {
+
   .slideshow--placeholder.banner--mobile-bottom.banner--adapt_image .slideshow__media,
   .slideshow--placeholder.banner--adapt_image:not(.banner--mobile-bottom) {
     height: 28rem;
@@ -40,7 +41,7 @@ slideshow-component .slideshow.banner {
   max-width: 54.5rem;
 }
 
-.slideshow__text > * {
+.slideshow__text>* {
   max-width: 100%;
 }
 
@@ -183,6 +184,7 @@ slideshow-component:not(.page-width) .slider-buttons {
 }
 
 @media screen and (forced-colors: active) {
+
   .slideshow__autoplay path,
   .slideshow__autoplay:hover path {
     fill: CanvasText;
@@ -198,4 +200,28 @@ slideshow-component:not(.page-width) .slider-buttons {
   visibility: hidden;
   opacity: 0;
   transform: scale(0.8);
+}
+
+.slideshow__media .slideshow__image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.slideshow__media .slideshow__image--desktop {
+  display: none;
+}
+
+.slideshow__media .slideshow__image--mobile {
+  display: block;
+}
+
+@media screen and (min-width: 750px) {
+  .slideshow.banner .slideshow__media .slideshow__image--desktop {
+    display: block;
+  }
+
+  .slideshow.banner .slideshow__media .slideshow__image--mobile {
+    display: none;
+  }
 }

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -3192,6 +3192,9 @@
               "options__3": {
                 "label": "Right"
               }
+            },
+            "image_mobile": {
+              "label": "Mobile image"
             }
           }
         }

--- a/locales/pt-BR.schema.json
+++ b/locales/pt-BR.schema.json
@@ -2847,6 +2847,9 @@
           "label": "Descrição da apresentação de slides",
           "info": "Descreva a apresentação de slides para quem usa leitores de tela",
           "default": "Apresentação de slides sobre nossa marca"
+        },
+        "image_mobile": {
+          "label": "Imagem para dispositivos móveis"
         }
       },
       "blocks": {
@@ -2946,6 +2949,9 @@
             },
             "header_colors": {
               "content": "Cores"
+            },
+            "image_mobile": {
+              "label": "Imagem para dispositivos móveis"
             }
           }
         }

--- a/sections/slideshow.liquid
+++ b/sections/slideshow.liquid
@@ -140,14 +140,28 @@
               {{
                 block.settings.image
                 | image_url: width: 3840
-                | image_tag: height: height, sizes: sizes, widths: widths, fetchpriority: fetch_priority
+                | image_tag: height: height, sizes: sizes, widths: widths, fetchpriority: fetch_priority, class: 'slideshow__image slideshow__image--desktop'
               }}
+              {%- if block.settings.image_mobile != blank -%}
+                {{
+                  block.settings.image_mobile
+                  | image_url: width: 750
+                  | image_tag: height: height, sizes: sizes, widths: widths, fetchpriority: fetch_priority, class: 'slideshow__image slideshow__image--mobile'
+                }}
+              {%- endif -%}
             {%- else -%}
               {{
                 block.settings.image
                 | image_url: width: 3840
-                | image_tag: loading: 'lazy', height: height, sizes: sizes, widths: widths
+                | image_tag: loading: 'lazy', height: height, sizes: sizes, widths: widths, class: 'slideshow__image slideshow__image--desktop'
               }}
+              {%- if block.settings.image_mobile != blank -%}
+                {{
+                  block.settings.image_mobile
+                  | image_url: width: 750
+                  | image_tag: loading: 'lazy', height: height, sizes: sizes, widths: widths, class: 'slideshow__image slideshow__image--mobile'
+                }}
+              {%- endif -%}
             {%- endif -%}
           {%- else -%}
             {%- assign placeholder_slide = forloop.index | modulo: 2 -%}

--- a/sections/slideshow.liquid
+++ b/sections/slideshow.liquid
@@ -396,6 +396,11 @@
           "label": "t:sections.slideshow.blocks.slide.settings.image.label"
         },
         {
+          "type": "image_picker",
+          "id": "image_mobile",
+          "label": "t:sections.slideshow.blocks.slide.settings.image_mobile.label"
+        },
+        {
           "type": "range",
           "id": "image_overlay_opacity",
           "min": 0,


### PR DESCRIPTION
Alterações referentes à tarefa técnica 2: Imagem mobile na seção de slideshow

"Na seção chamada Apresentação de slides (Slideshow), atualmente é possível definir apenas uma imagem para cada slide, usada tanto em desktop quanto em mobile. Adicione suporte a uma imagem alternativa para dispositivos móveis, obedecendo aos seguintes critérios:
  
  ● A imagem mobile deve ser editável no personalizador de tema.
  ● A imagem desktop deve ser exibida em telas grandes (desktop e tablet).
  ● A imagem mobile deve ser exibida apenas em dispositivos móveis."